### PR TITLE
bugfix: update react-select state - when moving between tabs

### DIFF
--- a/src/app/components/Forms/BillerForm.tsx
+++ b/src/app/components/Forms/BillerForm.tsx
@@ -32,6 +32,7 @@ export const BillerForm: FC = () => {
     useEffect(() => {
         getBillerIndex(uid);
         getBillerDetails(billerId);
+        console.log(billerId);
         // function createSelectorOptions() {
         //     let billerArray = [] as SelectorOptions[];
         //     console.log(allBillers!);
@@ -62,12 +63,13 @@ export const BillerForm: FC = () => {
                 <Selector
                     initOptions={selectorOptions}
                     setState={setBillerId}
+                    defaultValue={billerDetails.businessName!}
                 />
             </div>
         );
     }
 
-    function billerSaveButtonAction(
+    async function billerSaveButtonAction(
         e: React.MouseEvent<HTMLButtonElement, MouseEvent>
     ) {
         e.preventDefault();
@@ -77,6 +79,8 @@ export const BillerForm: FC = () => {
         console.log(
             "updating local state - push local state changes to Firebase"
         );
+        await getBillerIndex(uid);
+        setLoading(false);
     }
 
     return (

--- a/src/app/components/common/Selector.tsx
+++ b/src/app/components/common/Selector.tsx
@@ -30,9 +30,14 @@ export interface SelectorOptions {
 export interface SelectorProps {
     initOptions?: SelectorOptions[];
     setState?: Dispatch<SetStateAction<string>>;
+    defaultValue: string;
 }
 
-export const Selector: FC<SelectorProps> = ({ initOptions, setState }) => {
+export const Selector: FC<SelectorProps> = ({
+    initOptions,
+    setState,
+    defaultValue,
+}) => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [options, setOptions] = useState<SelectorOptions[]>(initOptions!);
     const [value, setValue] = useState<SelectorOptions | null>();
@@ -67,6 +72,7 @@ export const Selector: FC<SelectorProps> = ({ initOptions, setState }) => {
 
     return (
         <CreatableSelect
+            defaultInputValue={defaultValue}
             isClearable
             isDisabled={isLoading}
             isLoading={isLoading}

--- a/src/app/context/BillerProvider.tsx
+++ b/src/app/context/BillerProvider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ProviderProps } from ".";
+import { ProfileContextValue, ProviderProps, useProfileContext } from ".";
 import { SelectorOptions } from "../components/common";
 import { BuyerType, LocationType, PaymentDetailType } from "../types";
 import {
@@ -168,6 +168,7 @@ export const BillerProvider: FC<ProviderProps> = ({ children }) => {
     }
 
     async function updateBillerDetails() {
+        setLoading(true);
         const merchantRef = doc(db, "merchant", billerId);
         console.log(merchantRef);
         const locationRef = doc(db, "businessLocation", billerLocationId);


### PR DESCRIPTION
what?
> react select will display and retain state of 'currently selected' merchant
> still buggy - needs a double click to remove and to show all the options again